### PR TITLE
Structure update and new topics

### DIFF
--- a/_includes/di_filter.html
+++ b/_includes/di_filter.html
@@ -1,0 +1,16 @@
+{% for p in site.pages %}
+{% if p.url contains include.term and p.url contains include.projs %}
+<details>
+  <summary><b>{{p.title}}</b> (click to expand)</summary>
+  <ul>{{p.content | markdownify}}</ul>
+</details>
+{% endif %}
+{% endfor %}
+{% for p in site.static_files %}
+{% if p.path contains include.term and p.path contains include.projs %}
+<details>
+  <summary><b>{{p.title}}</b> (click to expand)</summary>
+  <ul>{{p.content | markdownify}}</ul>
+</details>
+{% endif %}
+{% endfor %}

--- a/index.html
+++ b/index.html
@@ -34,11 +34,11 @@ Physical: Gußhausstraße 27-29 (CA03), 1040 Vienna, Austria
 
 <h3> News </h3>
 <ol>
-<li>Our very own {% include linked_name.html id="TamaraDrucks" %} won the <a href="https://informatics.tuwien.ac.at/epilog/best-poster-award/">Best Poster Award</a> of TU Wien Informatics. Congratulations! (June '21)<br></li> 
+<li>Our very own {% include linked_name.html id="TamaraDrucks" %} won the <a href="https://informatics.tuwien.ac.at/epilog/best-poster-award/">Best Poster Award</a> of TU Wien Informatics. Congratulations! (Jan '22)<br></li> 
 <li>Our paper on <i><a href=https://pubs.acs.org/doi/10.1021/acs.jcim.1c00699>Kernel Methods for Predicting Yields of Chemical Reactions</a></i> has been accepted for publication in the <i>Journal of Chemical Information and Modeling</i>. Joint work of Alexe Haywood, Joseph Redshaw, Magnus Hanson-Heine, Adam Taylor, Alex  Brown, Andrew Mason, {% include linked_name.html id="ThomasGaertner" %}, and Jonathan Hirst. (Oct '21)
 </li>
 <li>
-Our paper on <i>Conditional Network Data Balancing With GANs</i> has been accepted at the <i>NeurIPS Deep Generative Models and Downstream Applications Workshop</i>. Joint work ok Fares Meghdouri, Thomas Schmied, Tanja Zseby, and {% include linked_name.html id="ThomasGaertner" %}. (Oct'21)
+Our paper on <i>Conditional Network Data Balancing With GANs</i> has been accepted at the <i>NeurIPS Deep Generative Models and Downstream Applications Workshop</i>. Joint work ok Fares Meghdouri, Thomas Schmied, Tanja Zseby, and {% include linked_name.html id="ThomasGaertner" %}. (Oct '21)
 </li>
 <li>Our paper on <i><a href=https://drive.google.com/file/d/1PZtXR8-o2qzuU2CnpW319LDI1mBIbR4e/view?usp=sharing>Active Learning Convex Halfspaces on Graphs</a></i> (<a href=https://drive.google.com/file/d/1ih__zFB1HYqBStNyizzN_raRN9042kzI/view?usp=sharing>supplementary material</a>) has been accepted at <b>NeurIPS 2021</b>. Congratulations to  {% include linked_name.html id="MaxThiessen" %} for his first NeurIPS paper! (Sept '21)<br> </li> 
 <li>Our team won the prize for the <i>Best Practical Result</i> in the <a href="https://ecosystem.siemens.com/topic/detail/default/33/overview">Siemens AI-Dependability Assessment Challenge</a>. Congratulations to {% include linked_name.html id="JosephRedshaw" %} (University of Nottingham), {% include linked_name.html id="MaxThiessen" %} (TU Wien), and {% include linked_name.html id="DavidPenz" %} (TU Wien)! (July '21)<br></li>
@@ -47,7 +47,7 @@ Our paper on <i>Conditional Network Data Balancing With GANs</i> has been accept
 <li>TU Wien has agreed to fund <a href="https://secint.visp.wien/people/">our</a> doctoral college on <i><a href="https://secint.visp.wien/">Secure and Intelligent Human-Centric
 Digital Technologies </a></i>! (July '20)</li>
 <li>Founding of the Machine Learning research unit. (Feb '20)</li>
-<li>BBSRC has aggreed to fund our proposal on <i>Bacteriphage to control Salmonella in pigs</i>! (October '19)</li>
+<li>BBSRC has aggreed to fund our proposal on <i>Bacteriphage to control Salmonella in pigs</i>! (Oct '19)</li>
 </ol>
 
 <h3>Topics</h3>

--- a/teaching/index.md
+++ b/teaching/index.md
@@ -14,19 +14,8 @@ title: Teaching
 
 <ul>
 <li> MSc <b>Lecture</b> <a href="./sose22/tfrtML.html"><i>Theoretical Foundations and Research Topics in Machine Learning (VU)</i></a></li>
-<li>MSc <b>Seminar</b> <a href="./sose22/seminar_msc.html"><i>Theoretical Aspects of Machine Learning Algorithms (SE)</i></a> 
-</li>
-
-<li> MSc <b>Project</b> <i>Machine Learning Algorithms and Applications (PR)</i>
-<br>We are happy to supervise machine learning related projects that are connected to our research interests. Examples are:
-{% include liq_filter.html term="sose22" projs="ana_projects" %}
-For other topics you will need to describe the scientific merit and novelty. It is very important to narrow down the rough topic to a tentative research question and approach of interest to us. The research question should not have been answered previously and the answer needs to be verifyable. To answer the question, typically one has to 
-<ul>
-<li>implement some machine learning algorithms and apply them to dataset,</li> 
-<li>implement an interesting application that uses machine learning, or</li>
-<li>prove some properties of a learning algorithm.</li>
-</ul>
-</li>
+<li> MSc <b>Seminar</b> <a href="./sose22/seminar_msc.html"><i>Theoretical Aspects of Machine Learning Algorithms (SE)</i></a></li>
+<li> MSc <b>Project</b> <a href="./sose22/ana.html"><i>Machine Learning Algorithms and Applications (PR)</i></a></li>
 <li> BSc <b>Seminar</b> <a href="./sose22/seminar_bsc.html"><i>Scientific Research and Writing (SE)</i></a></li>
 </ul>
 

--- a/teaching/sose22/ana.md
+++ b/teaching/sose22/ana.md
@@ -1,0 +1,72 @@
+---
+layout: entitled
+title: Machine Learning Algorithms and Applications
+---
+## General information
+
+- TISS: [(link)](https://tiss.tuwien.ac.at/course/courseDetails.xhtml?dswid=6801&dsrid=131&courseNr=193052&semester=2021W)
+- contact: [Tamara Drucks](mailto:tamara.drucks@tuwien.ac.at)
+- meeting link: [https://tuwien.zoom.us/my/tamaradrucks](https://tuwien.zoom.us/my/tamaradrucks)
+- everything important will be announced in TUWEL/TISS.
+
+
+## Format
+
+In this course, you will experience the role of a typical machine learning researcher.
+You will:
+* Familiarise yourself with a specific area of machine learning
+* Understand and summarise research papers
+* Work on a concrete problem/task in machine learning
+
+There are two types of projects:
+* **Applied**: implement and apply an algorithm, perform experiments, achieve good
+results on data
+* **Theoretical**: formulate proofs, find novel bounds, show the complexity of an algorithm
+
+---
+
+Working on the project consists of the following steps:
+
+##### 1. Problem statement
+
+Choose a project topic or come up with your own, original idea. Then, write a short problem statement, including your research question, motivation, related work, methodology, and expected results.
+
+##### 2. Working phase
+
+Work on your project and present your work to colleagues and our group. Additionally, you will have regular discussion meetings with your supervisor. 
+
+##### 3. Final submission
+
+Write a final report (short or full paper) to present your project, and design a poster. Your poster will be exhibited to your colleagues and our group during a poster session (snacks included, if Covid allows it!) at the end of the semester.
+
+
+## General resources (freely available books and lecture notes)
+
+- Understanding machine learning: from theory to algorithms. Shai Shalev-Shwartz and Shai Ben-David [(pdf)](https://www.cs.huji.ac.il/~shais/UnderstandingMachineLearning/copy.html)
+- Foundations of machine learning. Mehryar Mohri, Afshin Rostamizadeh, and Ameet Talwalkar [(pdf)](https://cs.nyu.edu/~mohri/mlbook/)
+- Foundations of data science. Avrim Blum, John Hopcroft, and Ravindran Kannan [(pdf)](https://www.cs.cornell.edu/jeh/book.pdf)
+- Mathematics for machine learning. Marc Peter Deisenroth, A. Aldo Faisal, and Cheng Soon Ong [(pdf)](https://mml-book.github.io/)
+- Mining of massive datasets. Jure Leskovec, Anand Rajaraman, and Jeffrey D. Ullman [(pdf)](http://infolab.stanford.edu/~ullman/mmds/book0n.pdf)
+- Reinforcement learning: an introduction. Richard Sutton and Andrew Barto [(pdf)](http://incompleteideas.net/book/the-book.html)
+- Research Methods in Machine Learning. Tom Dietterich [(pdf)](http://web.engr.oregonstate.edu/~tgd/talks/new-in-ml-2019.pdf)
+
+## Topics (Tentative)
+
+Here you can find a list of potential projects to choose from:
+
+#### Applied & theoretical projects
+
+{% include liq_filter.html term="sose22" projs="ana_projects" %}
+
+#### Competitions
+
+* [RecSys Challenge 2022](http://www.recsyschallenge.com/2022/)
+* [Kaggle](https://www.kaggle.com/)
+
+#### Your own idea!
+
+Describe the scientific merit and novelty of your idea. It is very important to narrow down the rough topic to a tentative research question and approach of interest to us. The research question should not have been answered previously and the answer needs to be verifiable. To answer the question, typically one has to:
+
+* implement some machine learning algorithms and apply them to dataset,
+* implement an interesting application that uses machine learning, or
+* prove some properties of a learning algorithm.

--- a/teaching/sose22/ana.md
+++ b/teaching/sose22/ana.md
@@ -4,7 +4,7 @@ title: Machine Learning Algorithms and Applications
 ---
 ## General information
 
-- TISS: [(link)](https://tiss.tuwien.ac.at/course/courseDetails.xhtml?dswid=6801&dsrid=131&courseNr=193052&semester=2021W)
+- TISS: [3.0EC](https://tiss.tuwien.ac.at/course/courseDetails.xhtml?dswid=5740&dsrid=553&courseNr=194101&semester=2022S&locale=en), [6.0EC](https://tiss.tuwien.ac.at/course/courseDetails.xhtml?dswid=3115&dsrid=873&courseNr=194119&semester=2022S&locale=en)
 - contact: [Tamara Drucks](mailto:tamara.drucks@tuwien.ac.at)
 - meeting link: [https://tuwien.zoom.us/my/tamaradrucks](https://tuwien.zoom.us/my/tamaradrucks)
 - everything important will be announced in TUWEL/TISS.
@@ -27,15 +27,15 @@ results on data
 
 Working on the project consists of the following steps:
 
-##### 1. Problem statement
+#### 1. Problem statement
 
 Choose a project topic or come up with your own, original idea. Then, write a short problem statement, including your research question, motivation, related work, methodology, and expected results.
 
-##### 2. Working phase
+#### 2. Working phase
 
 Work on your project and present your work to colleagues and our group. Additionally, you will have regular discussion meetings with your supervisor. 
 
-##### 3. Final submission
+#### 3. Final submission
 
 Write a final report (short or full paper) to present your project, and design a poster. Your poster will be exhibited to your colleagues and our group during a poster session (snacks included, if Covid allows it!) at the end of the semester.
 
@@ -54,16 +54,21 @@ Write a final report (short or full paper) to present your project, and design a
 
 Here you can find a list of potential projects to choose from:
 
-#### Applied & theoretical projects
+### Applied & theoretical projects
 
-{% include liq_filter.html term="sose22" projs="ana_projects" %}
+We are happy to supervise machine learning related projects that are connected to our research interests. Examples are:
 
-#### Competitions
+{% include di_filter.html term="sose22" projs="distinct_projects" %}
+
+
+{% comment %}
+### Competitions
 
 * [RecSys Challenge 2022](http://www.recsyschallenge.com/2022/)
 * [Kaggle](https://www.kaggle.com/)
+{% endcomment %}
 
-#### Your own idea!
+### Your own idea!
 
 Describe the scientific merit and novelty of your idea. It is very important to narrow down the rough topic to a tentative research question and approach of interest to us. The research question should not have been answered previously and the answer needs to be verifiable. To answer the question, typically one has to:
 

--- a/teaching/sose22/distinct_projects/projects_mt/convexity_real_world_graphs.md
+++ b/teaching/sose22/distinct_projects/projects_mt/convexity_real_world_graphs.md
@@ -1,0 +1,21 @@
+---
+layout: entitled
+title: Convexity in real-world graphs
+---
+
+**Question**:
+Do node labelled real-world graphs have (almost) *geodesically convex* classes?
+
+**Suggested approach**:
+Check for node-labelled graphs in benchmark datasets (e.g., http://snap.stanford.edu/data/), whether the classes (vertex sets corresponding with same node label) are convex. Try to find a more realisitic notion of convexity which, for example, allows outliers and disconnected regions.
+
+**Related work**:
+* Ignacio M. Pelayo "Geodesic Convexity in Graphs" (Springer 2013) (chapter 1, 2.1, 2.2, and 2.10) [(Researchgate link)](https://www.researchgate.net/profile/Ignacio-Pelayo/publication/299689772_Graph_Operations/links/5bf430334585150b2bc4952b/Graph-Operations.pdf)
+* Eike Stadtländer, Tamás Horváth, and Stefan Wrobel. "Learning weakly convex sets in metric spaces." (ECMLPKDD 2021)
+* Florian Seiffarth, Tamás Horváth, and Stefan Wrobel "Maximal Closed Set and Half-Space Separations in Finite Closure Systems." (ECMLPKDD 2019)
+* Maximilian Thiessen and Thomas Gärtner. "Active Learning of Convex Halfspaces on Graphs." (NeurIPS 2021).
+
+**Context**:
+While classical notions of convexity in Euclidean space are largely studied and used by the machine learning community, related notions in discrete spaces (e.g., graphs) have been mostly overlooked. A vertex set S is in a graph is *geodesically convex*, if all shortest paths joining two vertices in S stay in S. Recently, we (and other groups) have started to use the notion of convexity in graphs to achieve guarantees for machine learning problems on graphs.
+Currently, these results are mainly of theoretical interest, but the next step is to evaluate and test the developed methods on real-world graphs. For that, we have to find reasonable datasets and application areas that fit our convexity-based assumptions. Your goal is to identify graphs where the labelled subgraphs are (close to) convex.
+

--- a/teaching/sose22/distinct_projects/projects_mt/graph_based_active_learning.md
+++ b/teaching/sose22/distinct_projects/projects_mt/graph_based_active_learning.md
@@ -1,0 +1,21 @@
+---
+layout: entitled
+title: Graph-based active learning
+---
+
+**Task**:
+Implement and design an efficient (python) framework to compare graph-based active learning algorithms.
+
+**Suggested Approach**:
+The goal is to build a framework to compare different active learning algorithms more easily. Adding new active learning algorithms, new datasets, or new evaluation strategies should be as simple as possible. Data I/O, the active learning algorithms, the prediction algorithms, and the evaluations should be encapsulated and exchangeable (think of scikit-learn).
+
+**Related Work**:
+* Zhu, et al. "Combining active learning and semi-supervised learning using gaussian fields and harmonic functions." ICML 2003 workshop. [Matlab implementation](http://www.cs.cmu.edu/~zhuxj/pub/semisupervisedcode/active_learning/)
+* Ma, et al. "Σ-Optimality for Active Learning on Gaussian Random Fields." NIPS 2013. [Matlab implementation of their and related algorithms](https://github.com/yifeim/sigma_opt_codes)
+* graph cuts (Blum and Chawla. "Learning from labeled and unlabeled data using graph mincuts." ICML 2001. [Example implementation](https://github.com/syedhope/Graph-Cut)
+* Dasarathy, et al. "S2: an efficient graph based active learning algorithm with application to nonparametric classification." COLT 2015
+* Cesa-Bianchi, et al. "Active learning on trees and graphs", COLT 2013
+* Burr Settles, "Active Learning", Morgan & Claypool 2012.
+
+**Context**:
+Even though implementations of graph-based active learning algorithms are often available, it is tedious to evaluate and compare them on real-world graphs. Additionally, most existing active learning libraries like modAL, alipy and libact focus on heuristic (e.g., uncertainty based) methods, whereas we are interested in graph-based methods with theoretical guarantees. Because of that, our goal is to design an easy-to-use python framework that enables efficient evaluations and comparisons of graph-based methods. In the long run, it might be possible to integrate these implementations in popular machine learning libraries like scikit-learn (https://scikit-learn.org) or vowpal wabbit (https://vowpalwabbit.org/).

--- a/teaching/sose22/distinct_projects/projects_tg/analysis_bacteriophage_cocktails.md
+++ b/teaching/sose22/distinct_projects/projects_tg/analysis_bacteriophage_cocktails.md
@@ -1,0 +1,18 @@
+---
+layout: entitled
+title: Analysis of (Bacteriophage) Cocktails
+---
+
+This is an interdisciplinary project jointly with the [Department of Genetics and Genome Biology at the University of Leicester](https://le.ac.uk/ggb) and the [School of Life Sciences at the University of Nottingham](https://www.nottingham.ac.uk/life-sciences/index.aspx),
+
+**Question**: How can we find the most effective (Bacteriophage) Cocktail?
+
+**Suggested Approach**: Learning with structured data, structured output prediction, constructive machine learning.
+
+**Related Works**:
+ -  Dino Oglic, Steven A. Oatley, Simon J. F. Macdonald, Thomas Mcinally, Roman Garnett, Jonathan D. Hirst, and Thomas Gärtner. Active search for computer-aided drug design. Molecular Informatics, 2018. 
+ -  Dino Oglic, Roman Garnett, and Thomas Gärtner. Active search in intensionally specified structured spaces. In Proceedings of the Thirty-First AAAI Conference on Artificial Intelligence, 2017.
+
+**Context**:
+Antimicrobial resistance is a growing problem in many types of bacteria which cause disease (pathogens) in animals and humans. There is an urgent need to find alternatives to antibiotics which are more sustainable. Bacteriophages are viruses which infect and kill bacteria. They are quite specific, only affecting the targeted bacterial species while leaving other bacteria, which may be beneficial, unharmed. Unlike other viruses,
+phages do not infect the cells of animals or humans and can be found widely in the environment. We will use machine learning to predict which phage(cocktail)s will infect Salmonella under different conditions.

--- a/teaching/sose22/distinct_projects/projects_tg/cross_target_learning.md
+++ b/teaching/sose22/distinct_projects/projects_tg/cross_target_learning.md
@@ -1,0 +1,16 @@
+---
+layout: entitled
+title: Cross-target Learning
+---
+
+**Question**: How can we use data from related tasks for effective learning? (across multiple biological targets and/or across languages)
+
+**Suggested Approach**: Embedding them in the same space.
+
+**Related Works**:
+ - Dino Oglic, Daniel Paurat, and Thomas Gärtner. Interactive Knowledge-Based Kernel PCA. Proceedings of ECML PKDD, 2014. 
+ - Sven Giesselbach, Katrin Ullrich, Michael Kamp, Daniel Paurat, and Thomas Gärtner. Corresponding Projections for Orphan Screening. https://arxiv.org/abs/1812.00058
+
+**Context**:
+In many applications of machine learning one has to start making decisions without having access to lablelled training data specific to the task at hand. One approach in that case 
+is to transfer knowledge from similar tasks. In this project we will explore approaches that jointly embed tasks and hypotheses in the same space to find a good starting hypothesis for a novel (*``orphan''*) task. 

--- a/teaching/sose22/distinct_projects/projects_tg/emotional_status_biosignals.md
+++ b/teaching/sose22/distinct_projects/projects_tg/emotional_status_biosignals.md
@@ -1,0 +1,16 @@
+---
+layout: entitled
+title: Extracting Emotional Status from Biosignals
+---
+
+This is an interdisciplinary project jointly with the [Institute for Computer Technology (ICT) at TU Wien](https://www.ict.tuwien.ac.at/en/).
+
+**Question**: How well can we predict emotions from raw biosignals?
+
+**Suggested Approach**: Kernel methods in Kreı̆n Space.
+
+**Related Works**: 
+ - Dino Oglic and Thomas Gärtner. Learning in Reproducing Kernel Kreı̆n Spaces. In Proceedings of the 35th International Conference on Machine learning, 2018.
+  - David Pollreisz and Nima TaheriNejad. A Simple Algorithm for Emotion Recognition, Using Physiological Signals'of a Smart Watch. 39th Annual International Conference of the IEEE Engineering in Medicine and Biology Society, 2017.
+  
+**Context**: You will be given a set of raw biosignals (PPG, EDA, temperature, and acceleration) collected by a smartwatch as well as certain features (heart rate, respiratory rate, ...) that can be extracted from these signals. These data were collected while subjects were exposed to emotional stimuli. They then labeled these data with the emotions they felt and its respective strength. The objective is to develop a suitable ML algorithm that can accurately and reliably tag the biosignals (using the raw data and/or extracted features) with those emotions or a subset of those emotions.

--- a/teaching/sose22/distinct_projects/projects_tg/robust_machine_learning.md
+++ b/teaching/sose22/distinct_projects/projects_tg/robust_machine_learning.md
@@ -1,0 +1,15 @@
+---
+layout: entitled
+title: Robust Machine Learning
+---
+
+**Question**: How can we find robust hypotheses that attackers cannot easily manipulate?
+
+**Suggested Approach**: Approximate Tukey center of hypotheses via iterated Radon points.
+
+**Related Works**:
+ - Michael Kamp, Mario Boley, Olana Missura, and Thomas Gärtner. Effective Parallelisation for Machine Learning. Accepted for publication in Advances in Neural Information Processing Systems 30, 2017.
+ - Ran Gilad-Bachrach, Amir Navot, and Naftali Tishby. Bayes and Tukey Meet at the Center Point. COLT 2004: Learning Theory. 
+
+**Context**:
+The more (distributed) machine learning algorithms and/or the models learned by them are to be applied in critical applications where lives depend on predictions, the more trustworthy they need to be. For that, (distributed) learning algorithms need to be robust to manipulation of (training) data and communication channels. They also need to guarantee that their models have well-calibrated confidence. The Tukey center is a high-dimensional generalisation of the median and shares similar stability properties that will be exploited in this project.

--- a/teaching/sose22/distinct_projects/projects_tg/scalable_interactive_analysis.md
+++ b/teaching/sose22/distinct_projects/projects_tg/scalable_interactive_analysis.md
@@ -1,0 +1,15 @@
+---
+layout: entitled
+title: Scalable Interactive Analysis
+---
+
+**Question**: How can constraints be incorporated into meaningful low-dimensional embeddings of large data sets?
+
+**Suggested Approach**: Approximate knowledge-constrained PCA via the power method.
+
+**Related Works**:
+-  Dino Oglic, Daniel Paurat, and Thomas Gärtner. Interactive Knowledge-Based Kernel PCA. Proceedings of ECML PKDD, 2014. Springer.
+-  Daniel Paurat and Thomas Gärtner. InVis: A Tool for Interactive Visual Data Analysis. Proceedings of ECML PKDD, 2013. Springer.
+
+**Context**:
+Traditionally, embedding techniques focus on finding one fixed embedding, which depends on some technical parameters and emphasises a singular aspects of the data. In contrast, interactive data exploration aims at allowing the user to explore the structure of a dataset by observing a projection dynamically controlled by the user in an *intuitive* way. Ultimately it provides a way to search and find an embedding, emphasising aspects that the user desires to highlight. Current approaches often do not allow for real-time manipulation of large data sets.

--- a/teaching/sose22/seminar_bsc.md
+++ b/teaching/sose22/seminar_bsc.md
@@ -5,29 +5,11 @@ title: Bachelor Seminar Wissenschaftliches Arbeiten
 
 ## General information
 
-- introductory slides: coming soon
 - TISS: [(link)](https://tiss.tuwien.ac.at/course/courseDetails.xhtml?courseNr=193052&semester=2022S&dswid=6676&dsrid=709)
 - contact: [Patrick Indri](mailto:patrick.indri@tuwien.ac.at)
 - meeting link: [https://tuwien.zoom.us/my/patrickindri](https://tuwien.zoom.us/my/patrickindri)
 - everything important will be announced in TUWEL/TISS.
 
-
-## Timeline
-
-Kickoff-Meeting: 22.03. 15:00 in [https://tuwien.zoom.us/my/patrickindri](https://tuwien.zoom.us/my/patrickindri)
-
-| Date                    | Deadline                                                 |
-| -----------             | ----------:                                              |
-| 22.03.22 15:00          | kickoff [(here)](https://tuwien.zoom.us/my/patrickindri) |
-| Apr                     | spotlight and abstract                                   |
-| Apr                     | bidding                                                  |
-| May                     | first supervisor meeting                                 |
-| May-Jun                 | progress presentation and draft report                   |
-| Jun                     | second supervisor meeting                                |
-| Jun                     | reviewing your peers                                     |
-| Jun                     | final presentation and report                            |
-
-Precise dates will be made available on TUWEL.
 
 ## Format
 This seminar simulates a machine learning conference, where the students take on the role of authors and reviewers. It consists of multiple phases.
@@ -189,7 +171,7 @@ You should have access to the literature and papers through Google scholar, DBLP
 </details>
 
 <details>
-  <summary><b>(Graph) Representation Learning</b> (click to expand)</summary>
+  <summary><b>Knowledge graph embedding</b> (click to expand)</summary>
 
 <p>Overview:</p>
 <ul>
@@ -199,9 +181,11 @@ You should have access to the literature and papers through Google scholar, DBLP
 <p>Papers and projects:</p>
 <ul>
 <li>Knowledge Graph Embeddings (focus on deep learning approaches)</li>
+<ul>
 <li>Q. Wang, Z. Mao, B. Wang, L. Guo. "Knowledge Graph Embedding: A Survey of Approaches and Applications", 2017</li>
 <li>Y. Dai, S. Wang, N. Xiong, W. Guo. "A Survey on Knowledge Graph Embedding: Approaches, Applications and Benchmarks", 2020</li>
 <li>M. Wang, L. Qiu, X. Wang. "A Survey on Knowledge Graph Embeddings for Link Prediction", 2021</li>
+</ul>
 </ul>
 
 </details>

--- a/teaching/sose22/seminar_bsc.md
+++ b/teaching/sose22/seminar_bsc.md
@@ -16,7 +16,7 @@ This seminar simulates a machine learning conference, where the students take on
 
 ### 1. Proposal phase
 
-Attend the **mandatory** first meeting on 22.03.2022, 15:00 (**[https://tuwien.zoom.us/my/patrickindri](https://tuwien.zoom.us/my/patrickindri)**).
+Attend the **mandatory** first meeting on 22.03.2022, 15:00 (either in person in **Seminarraum 127** in Gußhausstr. 27-29, room CD 03 24, or remotely at **[https://tuwien.zoom.us/my/patrickindri](https://tuwien.zoom.us/my/patrickindri)**).
 
 #### Option 1: our suggestions
  > You select **two** projects/papers (i.e. two bullet points) from one of the topics below. You will work with the material mentioned in the overview and the project-specific resources.   

--- a/teaching/sose22/seminar_bsc.md
+++ b/teaching/sose22/seminar_bsc.md
@@ -223,3 +223,28 @@ You should have access to the literature and papers through Google scholar, DBLP
 </ul>
 
 </details>
+
+
+<details>
+  <summary><b>Explainable AI</b> (click to expand)</summary>
+  
+<p>Overview:</p>
+<ul>
+  <li>Došilović, Filip Karlo, Mario Brčić, and Nikica Hlupić. "Explainable artificial intelligence: A survey." MIPRO 2018</li>
+  <li> Samek, Wojciech, and Klaus-Robert Müller. "Towards explainable artificial intelligence." Explainable AI: interpreting, explaining and visualizing deep learning." Springer, Cham, 2019 </li>
+</ul>
+<p>Papers and projects:</p>
+<ul>
+  <li>interpreting model predictions</li>
+  <ul>
+    <li>Ribeiro, Marco Tulio, Sameer Singh, and Carlos Guestrin. ""Why should i trust you?" Explaining the predictions of any classifier." ACM SIGKDD 2016</li>
+    <li>Lundberg, Scott M., and Su-In Lee. "A unified approach to interpreting model predictions." NIPS 2017</li>
+  </ul>
+  <li>reliability of saliency methods</li>
+  <ul>
+    <li>Adebayo, Julius, et al. "Sanity checks for saliency maps." NIPS 2018</li>
+    <li>Kindermans, Pieter-Jan, et al. "The (un) reliability of saliency methods." Explainable AI: Interpreting, Explaining and Visualizing Deep Learning, Springer, Cham, 2019</li>
+  </ul>
+</ul>
+
+</details>

--- a/teaching/sose22/seminar_msc.md
+++ b/teaching/sose22/seminar_msc.md
@@ -63,7 +63,7 @@ Give a final presentation and submit your report.
 You should have access to the literature and papers through Google scholar, DBLP, the provided links, or the TU library.
 
 <details>
-  <summary><b>(Graph) Representation Learning</b> (click to expand)</summary>
+  <summary><b>Knowledge Graph Embeddings</b> (click to expand)</summary>
 
 <p>Overview:</p>
 <ul>

--- a/teaching/sose22/seminar_msc.md
+++ b/teaching/sose22/seminar_msc.md
@@ -15,10 +15,10 @@ This seminar simulates a machine learning conference, where the students take on
 
 ### 1. Proposal phase
 
-Attend the **mandatory** first meeting on 07.03, 15:00 (**[https://tuwien.zoom.us/my/maxthiessen](https://tuwien.zoom.us/my/maxthiessen)**).
+Attend the **mandatory** first meeting on 07.03, 15:00 (either in person at **Gußhausstraße 27-29 CA 03 13**, or remotely at **[https://tuwien.zoom.us/my/maxthiessen](https://tuwien.zoom.us/my/maxthiessen)**).
 
 #### Option 1: our suggestions
- > You select **two** projects/papers (i.e. two bullet points) from one of the topics below. You will work with the material mentioned in the overview and the project-specific resources.   
+ > You select **two** projects/papers (i.e., two bullet points) from one of the topics below. You will work with the material mentioned in the overview and the project-specific resources.   
 
 #### Option 2: your own projects
  > You choose **two** different own project ideas to work on. This can be some existing machine learning paper/work or an own creative idea in the context of machine learning. Importantly, it has to be specific and worked out well.

--- a/teaching/sose22/seminar_msc.md
+++ b/teaching/sose22/seminar_msc.md
@@ -4,7 +4,7 @@ title: Seminar on Theoretical Aspects of Machine Learning Algorithms
 ---
 ## General information
 
-- TISS: [(link)](https://tiss.tuwien.ac.at/course/courseAnnouncement.xhtml?dswid=5896&dsrid=205&courseNumber=194102&courseSemester=2021W&locale=en)
+- TISS: [(link)](https://tiss.tuwien.ac.at/course/courseDetails.xhtml?dswid=9375&dsrid=649&courseNr=194118&semester=2022S)
 - contact: [Maximilian Thiessen](mailto:maximilian.thiessen@tuwien.ac.at)
 - meeting link: [https://tuwien.zoom.us/my/maxthiessen](https://tuwien.zoom.us/my/maxthiessen)
 - everything important will be announced in TUWEL/TISS.
@@ -127,63 +127,6 @@ You should have access to the literature and papers through Google scholar, DBLP
 
 
 <details>
-  <summary><b>Clustering and dimensionality reduction</b> (click to expand)</summary>
-
-<p>Overview:</p>
-<ul>
-<li>chapter 1 and 2 of "Dimension reduction: a guided tour" by Christopher Burges, 2010, <strong>and</strong> chapter 22 (the introduction section before 22.1 and section 22.5) of "Understanding machine learning".</li>
-<li>introduction and theoretical overview on clustering: Shai Ben-David Cheriton Symposium 2017 <a href="https://www.youtube.com/watch?v=Pq5d1Y2YpgA">(youtube-link)</a></li>
-<li>introduction and overview on probabilistic dimensionality reduction: Neil Lawrence - MLSS 2012 <a href="https://www.youtube.com/watch?v=RmjMLeYXDnI">(youtube-link)</a></li>
-</ul>
-<p>Papers and projects:</p>
-<ul>
-<li>kernel PCA and multidimensional scaling (Schölkopf, et al. "Kernel principal component analysis." ICANN 1997 <strong>and</strong> Williams "On a connection between kernel PCA and metric multidimensional scaling." Machine learning 2002)</li>
-<li>spectral clustering (Von Luxburg. "A tutorial on spectral clustering." Statistics and computing 2007)</li>
-<li>(adaptive) correlation clustering (Bansal, et al. "Correlation clustering." Machine learning 2004 <strong>and</strong> Bressan, Marco, et al. "Correlation clustering with adaptive similarity queries." NeurIPS 2019)</li>
-<li>(approximate) k-means++ (Arthur and Vassilvitskii. "k-means++: The advantages of careful seeding." Stanford, 2006 <strong>and</strong> Bachem, Olivier, et al. "Approximate k-means++ in sublinear time." AAAI 2016)</li>
-<li>clustering under approximation stability (Balcan, et al. "Clustering under approximation stability." Journal of the ACM 2013)</li>
-<li>auto-encoders and generative adversarial nets (Diederik and Welling "Auto-encoding variational Bayes" ICLR 2014 <strong>and</strong> Goodfellow, et al. "Generative adversarial nets" NIPS 2014 <strong>and</strong> Tolstikhin, et al. "Wasserstein auto-encoders" ICLR 2018)</li>
-</ul>
-
-</details>
-
-<details>
-  <summary><b>Theory of graph neural networks (GNNs)</b> (click to expand)</summary>
-
-<p>Overview:</p>
-<ul>
-<li>chapter 1 and 5 of "Graph representation learning" by William L. Hamilton <a href="https://www.cs.mcgill.ca/~wlh/grl_book/">(pdf)</a></li>
-<li>Xu, et al. "How Powerful are Graph Neural Networks?" ICLR 2019</li>
-<li>introduction and overview on graph neural networks: Petar Veličković - Tensorflow Tech Talks 2021 <a href="https://www.youtube.com/watch?v=8owQBFAHw7E">(youtube-link)</a></li>
-</ul>
-<p>Papers and topics:</p>
-<ul>
-<li>k-dimensional Weisfeiler Leman and GNNs (Morris, et al. "Weisfeiler and Leman Go Neural: Higher-order Graph Neural Networks." AAAI 2019 <strong>and</strong> Morris, et al. "Weisfeiler and Leman go sparse: Towards scalable
-higher-order graph embeddings." NeurIPS 2020)</li>
-<li>subgraph counts and GNNs (Barceló, et al. "Graph Neural Networks with Local Graph Parameters" arXiv:2106.06707 2021 <strong>and</strong> Chen, et al. "Can Graph Neural Networks Count Substructures? NeurIPS 2020)</li>
-<li>homomorphisms and GNNs (NT and Maehara "Graph Homomorphism Convolution." ICML 2020 <strong>and</strong> Dell, et al. "Lovász Meets Weisfeiler and Leman." ICALP 2018)</li>
-</ul>
-
-</details>
-
-<details>
-  <summary><b>Equivariant neural networks</b> (click to expand)</summary>
-
-
-<p>Overview:</p>
-<ul>
-<li>chapter 8 "equivariant neural networks" of "Deep learning for molecules and materials" by Andrew D. White, 2021. <a href="https://whitead.github.io/dmol-book/dl/Equivariant.html">(pdf)</a></li>
-<li>introduction to equivariance: Taco Cohen and Risi Kondor - Neurips 2020 Tutorial (first half) <a href="https://slideslive.com/38943570/equivariant-networks">(slideslive-link)</a></li>
-</ul>
-<p>Papers and projects:</p>
-<ul>
-<li>group equivariance (Esteves. "Theoretical aspects of group equivariant neural networks", <a href="https://arxiv.org/abs/2004.05154">arXiv 2020</a>)</li>
-<li>equivariant CNNS on homogeneous spaces (Cohen, et al. "A General theory of equivariant CNNs on homogeneous spaces." Neurips 2019)</li>
-</ul>
-
-</details>
-
-<details>
   <summary><b>Graph kernels</b> (click to expand)</summary>
 
 <p>Overview:</p>
@@ -218,21 +161,6 @@ higher-order graph embeddings." NeurIPS 2020)</li>
 
 </details>
 
-<details>
-  <summary><b>Causal inference</b> (click to expand)</summary>
- 
-<p>Overview:</p>
-<ul>
-<li>chapter 1 to 3 of "Elements of causal inference" by Jonas Peters, Dominik Janzing, and Bernhard Schölkopf, 2017 <a href="https://mitpress.mit.edu/books/elements-causal-inference">(pdf)</a></li>
-<li>introduction to causal inference: Bernhard Schölkopf - MLSS 2020 <a href="https://www.youtube.com/watch?v=btmJtThWmhA">(youtube-link)</a></li>
-</ul>
-<p>Papers and projects:</p>
-<ul>
-<li>transfer learning (Rojas-Carulla, et al. "Invariant models for causal transfer learning." Journal of machine learning research 2019)</li>
-<li>causality and semi-supervised learning (chapter 5 of "Elements of causal inference" <strong>and</strong> Schölkopf, et al. "On causal and anticausal learning." ICML 2012)</li>
-</ul>
-
-</details>
 
 <details>
   <summary><b>Semi-supervised learning</b> (click to expand)</summary>
@@ -246,7 +174,6 @@ higher-order graph embeddings." NeurIPS 2020)</li>
 <ul>
 <li>transductive support vector machines (chapter 6 in SSL by Thorsten Joachims)</li>
 <li>large-margin semi-supervised learning (Wang, et al. "On efficient large margin semisupervised learning: method and theory." Journal of machine learning research 2009)</li>
-<li>label propagation and quadratic criterion (chapter 11 in SSL by Yoshua Bengio, Olivier Delalleau and Nicolas Le Roux)</li>
 <li>PAC model for semi-supervised learning (chapter 22 of SSL by Maria-Florina Balcan and Avrim Blum)</li>
 <li>generalization error bounds (Rigollet. "Generalization error bounds in semi-supervised classification under the cluster assumption." Journal of machine learning research 2007)</li>
 <li>regularization and semi-supervised learning on graphs (Belkin, et al. "Regularization and semi-supervised learning on large graphs." COLT 2004)</li>
@@ -292,6 +219,47 @@ higher-order graph embeddings." NeurIPS 2020)</li>
 <li>(online) learning with partial orders (Gärtner and  Garriga. "The cost of learning directed cuts." ECML 2007 <strong>and</strong> Missura and Gärtner. "Predicting dynamic difficulty." NIPS 2011)</li>
 </ul>
 
+</details>
+
+
+<details>
+  <summary><b>Clustering and dimensionality reduction</b> (click to expand)</summary>
+
+<p>Overview:</p>
+<ul>
+<li>chapter 1 and 2 of "Dimension reduction: a guided tour" by Christopher Burges, 2010, <strong>and</strong> chapter 22 (the introduction section before 22.1 and section 22.5) of "Understanding machine learning".</li>
+<li>introduction and theoretical overview on clustering: Shai Ben-David Cheriton Symposium 2017 <a href="https://www.youtube.com/watch?v=Pq5d1Y2YpgA">(youtube-link)</a></li>
+<li>introduction and overview on probabilistic dimensionality reduction: Neil Lawrence - MLSS 2012 <a href="https://www.youtube.com/watch?v=RmjMLeYXDnI">(youtube-link)</a></li>
+</ul>
+<p>Papers and projects:</p>
+<ul>
+<li>kernel PCA and multidimensional scaling (Schölkopf, et al. "Kernel principal component analysis." ICANN 1997 <strong>and</strong> Williams "On a connection between kernel PCA and metric multidimensional scaling." Machine learning 2002)</li>
+<li>spectral clustering (Von Luxburg. "A tutorial on spectral clustering." Statistics and computing 2007)</li>
+<li>(adaptive) correlation clustering (Bansal, et al. "Correlation clustering." Machine learning 2004 <strong>and</strong> Bressan, Marco, et al. "Correlation clustering with adaptive similarity queries." NeurIPS 2019)</li>
+<li>(approximate) k-means++ (Arthur and Vassilvitskii. "k-means++: The advantages of careful seeding." Stanford, 2006 <strong>and</strong> Bachem, Olivier, et al. "Approximate k-means++ in sublinear time." AAAI 2016)</li>
+<li>clustering under approximation stability (Balcan, et al. "Clustering under approximation stability." Journal of the ACM 2013)</li>
+<li>auto-encoders and generative adversarial nets (Diederik and Welling "Auto-encoding variational Bayes" ICLR 2014 <strong>and</strong> Goodfellow, et al. "Generative adversarial nets" NIPS 2014 <strong>and</strong> Tolstikhin, et al. "Wasserstein auto-encoders" ICLR 2018)</li>
+</ul>
+
+</details>
+
+
+<details>
+  <summary><b>Modern aspects of learning theory</b> (click to expand)</summary>
+<p>Overview:</p>
+<ul>
+<li>Olivier Bousquet Stéphane Boucheron, and Gábor Lugosi: "Introduction to Statistical Learning Theory" 2003.</li>
+<li>Chapters 1-6 of "Understanding machine learning" </li>
+<li> "Extending Generalization Theory Towards Addressing Modern Challenges in ML" by Shay Moran, talk at the HUJI ML Club, 2021 <a href="https://www.youtube.com/watch?v=E6Umv6XBJck">(youtube-link)</a></li>
+<li> (Basic material) Statistical Machine Learning by Ulrike von Luxburg (we recommend part 38-41) <a href="https://www.youtube.com/playlist?list=PL05umP7R6ij2XCvrRzLokX6EoHWaGA2cC">(youtube playlist)</a></li>
+</ul>
+<p>Papers and projects:</p>
+<ul>
+<li>partial concept classes (Alon, et al., "A theory of PAC learnability of partial concept classes", unpublished arXiv:2107.08444)</li>
+<li>tight bounds (Bousquet, et al., "Proper learning, Helly number, and an optimal SVM bound" COLT 2020)</li>
+<li>universal learning (Bousquet, et al., "A theory of universal learning" STOC 2021)</li>
+<li>sample compression schemes (Moran, et al., "Sample compression schemes for VC classes" Journal of the ACM 2016).</li>
+</ul>
 </details>
 
 <details>

--- a/teaching/sose22/seminar_msc.md
+++ b/teaching/sose22/seminar_msc.md
@@ -293,3 +293,35 @@ higher-order graph embeddings." NeurIPS 2020)</li>
 </ul>
 
 </details>
+
+<details>
+  <summary><b>Explainable AI</b> (click to expand)</summary>
+  
+<p>Overview:</p>
+<ul>
+  <li>Došilović, Filip Karlo, Mario Brčić, and Nikica Hlupić. "Explainable artificial intelligence: A survey." MIPRO 2018</li>
+  <li> Samek, Wojciech, and Klaus-Robert Müller. "Towards explainable artificial intelligence." Explainable AI: interpreting, explaining and visualizing deep learning." Springer, Cham, 2019 </li>
+</ul>
+<p>Papers and projects:</p>
+<ul>
+  <li>interpreting model predictions with SHAP and LIME (Ribeiro, Marco Tulio, Sameer Singh, and Carlos Guestrin. ""Why should i trust you?" Explaining the predictions of any classifier." ACM SIGKDD 2016 <b>and</b> Lundberg, Scott M., and Su-In Lee. "A unified approach to interpreting model predictions." NIPS 2017</li>
+  <li>nonlinear classifiers (Montavon, Grégoire, et al. "Explaining nonlinear classification decisions with deep taylor decomposition." Pattern recognition, 2017)</li>
+</ul>
+
+</details>
+
+<details>
+  <summary><b>Differential privacy</b> (click to expand)</summary>
+  
+<p>Overview:</p>
+<ul>
+  <li>Dwork, Cynthia. "Differential privacy: A survey of results." International conference on theory and applications of models of computation. Springer, 2008)</li>
+  <li> Chapter 2 of: Dwork, Cynthia, and Aaron Roth. "The algorithmic foundations of differential privacy." Found. Trends Theor. Comput. Sci. 9.3-4 2014 </li>
+</ul>
+<p>Papers and projects:</p>
+<ul>
+  <li>differential privacy and deep learning (Chen, Xiangyi, Steven Z. Wu, and Mingyi Hong. "Understanding gradient clipping in private SGD: A geometric perspective." NeurIPS 2020)</li>
+  <li>(extensions of) gaussian mechanism (Balle, Borja, and Yu-Xiang Wang. "Improving the gaussian mechanism for differential privacy: Analytical calibration and optimal denoising." International Conference on Machine Learning. PMLR, 2018)</li>
+</ul>
+
+</details>


### PR DESCRIPTION
- Updated the teaching index, now linking to a single A&A page where all the projects are listed in a single, collapsible list.
- Small updates in the BS and MS pages (including adding some topics).
- Typos in homepage